### PR TITLE
Update embeddingEndpoints.ts

### DIFF
--- a/src/lib/server/embeddingEndpoints/openai/embeddingEndpoints.ts
+++ b/src/lib/server/embeddingEndpoints/openai/embeddingEndpoints.ts
@@ -30,7 +30,7 @@ export async function embeddingEndpointOpenAI(
 					headers: {
 						Accept: "application/json",
 						"Content-Type": "application/json",
-						...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+						...(apiKey ? { "Api-Key": apiKey } : {}),
 					},
 					body: JSON.stringify({ input: batchInputs, model: model.name }),
 				});


### PR DESCRIPTION
Adds the `Api-Key` Parameter instead of `Authorization` since OpenAI depends on API Key